### PR TITLE
Allow dll files to also be loaded

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ namespace Costura_Decompressor
                 }
 
                 //Check if the file is an executable
-                if (Path.GetExtension(inputFile) == ".exe")
+                if (Path.GetExtension(inputFile) == ".exe" || Path.GetExtension(inputFile) == ".dll")
                 {
                     ProcessExecutable(inputFile);
                     continue;
@@ -38,7 +38,7 @@ namespace Costura_Decompressor
                     continue;
                 }
 
-                Logger.Error("Unsupported file extension, accepts .exe or .compressed");
+                Logger.Error("Unsupported file extension, accepts \".exe\". \".dll\" or \".compressed\"");
             }
 
             Console.ReadKey();


### PR DESCRIPTION
It's a bit bothersome to have to rename them to .exe everytime I want to decompress one of these.